### PR TITLE
Add multi-range PacketSender source support

### DIFF
--- a/tunnels/PacketSender/common/helpers.c
+++ b/tunnels/PacketSender/common/helpers.c
@@ -49,6 +49,31 @@ static uint16_t packetsenderStoredLengthForProtocol(uint8_t protocol)
     }
 }
 
+static void packetsenderResolveSourceAddress(const packetsender_tstate_t *state, uint64_t source_index,
+                                             uint32_t *src_addr_host_out, uint32_t *src_addr_network_out)
+{
+    uint64_t remaining = source_index;
+
+    for (uint32_t ri = 0; ri < state->source_range_count; ++ri)
+    {
+        const packetsender_source_range_t *range = &state->source_ranges[ri];
+
+        if (remaining < range->count)
+        {
+            const uint32_t src_addr_host = range->base_host + (uint32_t) remaining;
+            *src_addr_host_out          = src_addr_host;
+            *src_addr_network_out       = lwip_htonl(src_addr_host);
+            return;
+        }
+
+        remaining -= range->count;
+    }
+
+    LOGF("PacketSender: internal error, source index %llu is out of range",
+         (unsigned long long) source_index);
+    terminateProgram(1);
+}
+
 static uint16_t packetsenderSelectSourcePort(const packetsender_tstate_t *state, uint32_t src_addr_host, uint8_t protocol)
 {
     if (! packetsenderProtocolUsesPorts(protocol))
@@ -235,8 +260,10 @@ static void packetsenderResolvePacketView(const packetsender_tstate_t *state, ui
         offset       = (size_t) source_index * state->fixed_packet_length;
     }
 
-    const uint32_t src_addr_host    = state->source_base_host + (uint32_t) source_index;
-    const uint32_t src_addr_network = lwip_htonl(src_addr_host);
+    uint32_t src_addr_host    = 0;
+    uint32_t src_addr_network = 0;
+
+    packetsenderResolveSourceAddress(state, source_index, &src_addr_host, &src_addr_network);
 
     *packet_ptr_out       = state->packet_bytes + offset;
     *packet_len_out       = packet_len;
@@ -437,6 +464,11 @@ void packetsenderPrepareRuntime(tunnel_t *t)
 
         state->protocol_offsets[kPacketSenderProtocolsPerSource] = running_offset;
         bytes_per_source   = running_offset;
+        if (state->source_count > (UINT64_MAX / kPacketSenderProtocolsPerSource))
+        {
+            LOGF("PacketSender: total packet count would overflow");
+            terminateProgram(1);
+        }
         state->total_packets = state->source_count * kPacketSenderProtocolsPerSource;
     }
     else
@@ -473,9 +505,11 @@ void packetsenderPrepareRuntime(tunnel_t *t)
 
     for (uint64_t source_index = 0; source_index < state->source_count; ++source_index)
     {
-        const uint32_t src_addr_host    = state->source_base_host + (uint32_t) source_index;
-        const uint32_t src_addr_network = lwip_htonl(src_addr_host);
+        uint32_t       src_addr_host    = 0;
+        uint32_t       src_addr_network = 0;
         uint8_t       *source_base      = state->packet_bytes + ((size_t) source_index * state->bytes_per_source);
+
+        packetsenderResolveSourceAddress(state, source_index, &src_addr_host, &src_addr_network);
 
         if (state->protocol_mode == kPacketSenderProtocolAll)
         {

--- a/tunnels/PacketSender/description.md
+++ b/tunnels/PacketSender/description.md
@@ -5,11 +5,12 @@ store at startup and then schedules those packets smoothly across the configured
 lines.
 
 It is meant for one-way packet generation toward another packet-capable adapter such as `RawSocket`.
+It can also accept multiple IPv4 source ranges and walk them in order, finishing one range before moving to the next.
 
 ## What It Does
 
 - acts as a chain-head packet adapter
-- accepts an IPv4 CIDR source range and one IPv4 destination
+- accepts one or more IPv4 CIDR source ranges and one IPv4 destination
 - pre-generates every packet before transmission begins
 - sends packets on the upstream path with `tunnelNextUpStreamPayload()`
 - never closes the shared worker packet lines during normal runtime
@@ -36,7 +37,10 @@ TCP-only:
   "name": "packet-sender",
   "type": "PacketSender",
   "settings": {
-    "source-ip4-range": "198.51.100.0/24",
+    "source-ip4-range": [
+      "198.51.100.0/24",
+      "203.0.113.0/24"
+    ],
     "dest-ip4": "203.0.113.20",
     "protocol-number": "TCP",
     "duration-ms": 5000,
@@ -80,11 +84,16 @@ All protocols:
 
 ### `settings`
 
-- `source-ip4-range` `(string)`
-  Required IPv4 CIDR range, for example `"198.51.100.0/24"`.
+- `source-ip4-range` `(string or array of strings)`
+  Required IPv4 CIDR range or ordered list of IPv4 CIDR ranges, for example:
+  - `"198.51.100.0/24"`
+  - `["198.51.100.0/24", "203.0.113.0/24"]`
 
-  `PacketSender` normalizes this to the subnet base implied by the prefix and generates one packet source address for
-  every IPv4 address in that subnet.
+  `PacketSender` normalizes each subnet to its base address and generates one packet source address for every IPv4
+  address in each subnet.
+
+  When an array is provided, ranges are consumed in the array order: the first range is exhausted, then the second,
+  then the third, and so on.
 
 - `dest-ip4` `(string)`
   Required destination IPv4 address.
@@ -202,4 +211,5 @@ node.
 - it is intentionally one-way and does not expose a downstream client-facing side
 - `dest-port` and `src-port` are used only for generated TCP and UDP packets
 - when `protocol-number` is `ALL`, the TCP and UDP packets inside the set still use those configured ports
+- when `source-ip4-range` is an array, `PacketSender` walks the ranges in order and does not interleave them
 - because it is a layer-3 chain head, worker packet-line init is supplied by Waterwall's normal packet-chain bootstrap

--- a/tunnels/PacketSender/include/structure.h
+++ b/tunnels/PacketSender/include/structure.h
@@ -17,15 +17,23 @@ typedef struct packetsender_worker_state_s
     wid_t     wid;
 } packetsender_worker_state_t;
 
+typedef struct packetsender_source_range_s
+{
+    uint32_t base_host;
+    uint64_t count;
+    uint8_t  prefix_length;
+    uint8_t  _padding[7];
+} packetsender_source_range_t;
+
 typedef struct packetsender_tstate_s
 {
-    uint32_t source_base_host;
+    packetsender_source_range_t *source_ranges;
+    uint32_t source_range_count;
     uint32_t dest_addr_host;
     uint32_t dest_addr_network;
     uint32_t duration_ms;
     uint16_t dest_port;
     uint16_t src_port;
-    uint8_t  source_prefix_length;
     uint8_t  protocol_mode;
     bool     src_port_random;
     uint8_t  _padding0;

--- a/tunnels/PacketSender/instance/create.c
+++ b/tunnels/PacketSender/instance/create.c
@@ -12,6 +12,12 @@ static bool packetsenderParseIpv4String(uint32_t *dest, const char *ipbuf, const
 {
     ip4_addr_t parsed_ipv4;
 
+    if (ipbuf == NULL || ipbuf[0] == '\0')
+    {
+        LOGF("JSON Error: %s (string field) : expected a single IPv4 address", json_path);
+        return false;
+    }
+
     if (ip4AddrAddressToNetwork(ipbuf, &parsed_ipv4) == 0)
     {
         LOGF("JSON Error: %s (string field) : expected a single IPv4 address", json_path);
@@ -22,40 +28,109 @@ static bool packetsenderParseIpv4String(uint32_t *dest, const char *ipbuf, const
     return true;
 }
 
-static bool packetsenderLoadSourceRange(packetsender_tstate_t *state, const cJSON *settings)
+static bool packetsenderParseSourceRange(packetsender_source_range_t *range, const char *cidr, const char *json_path)
 {
-    char *cidr = NULL;
+    ip_addr_t ip;
+    ip_addr_t subnet_mask;
+    int       prefix_length = -1;
 
-    if (! getStringFromJsonObject(&cidr, settings, "source-ip4-range"))
+    if (cidr == NULL || cidr[0] == '\0')
     {
-        LOGF("JSON Error: PacketSender->settings->source-ip4-range (string field) : expected an IPv4 CIDR range");
+        LOGF("JSON Error: %s (string field) : expected an IPv4 CIDR range", json_path);
         return false;
     }
 
     if (! verifyIPCdir(cidr))
     {
-        LOGF("JSON Error: PacketSender->settings->source-ip4-range (string field) : invalid IPv4 CIDR range");
-        memoryFree(cidr);
+        LOGF("JSON Error: %s (string field) : invalid IPv4 CIDR range", json_path);
         return false;
     }
-
-    ip_addr_t ip;
-    ip_addr_t subnet_mask;
-    int       prefix_length = -1;
 
     if (parseIPWithSubnetMask(cidr, &ip, &subnet_mask) != 4 ||
         sscanf(cidr, "%*[^/]/%d", &prefix_length) != 1 || prefix_length < 0 || prefix_length > 32)
     {
-        LOGF("JSON Error: PacketSender->settings->source-ip4-range (string field) : expected an IPv4 CIDR range");
-        memoryFree(cidr);
+        LOGF("JSON Error: %s (string field) : expected an IPv4 CIDR range", json_path);
         return false;
     }
 
-    state->source_base_host      = lwip_ntohl(ip.u_addr.ip4.addr) & lwip_ntohl(subnet_mask.u_addr.ip4.addr);
-    state->source_prefix_length  = (uint8_t) prefix_length;
-    state->source_count          = 1ULL << (32U - (uint32_t) prefix_length);
+    range->base_host = lwip_ntohl(ip.u_addr.ip4.addr) & lwip_ntohl(subnet_mask.u_addr.ip4.addr);
+    range->prefix_length = (uint8_t) prefix_length;
+    range->count = 1ULL << (32U - (uint32_t) prefix_length);
+    return true;
+}
 
-    memoryFree(cidr);
+static bool packetsenderLoadSourceRanges(packetsender_tstate_t *state, const cJSON *settings)
+{
+    const cJSON *range_json = cJSON_GetObjectItemCaseSensitive(settings, "source-ip4-range");
+
+    if (range_json == NULL)
+    {
+        LOGF("JSON Error: PacketSender->settings->source-ip4-range (string or array field) : expected one or more IPv4 CIDR ranges");
+        return false;
+    }
+
+    const cJSON *items       = range_json;
+    int          range_count = 0;
+
+    if (cJSON_IsString(range_json) && range_json->valuestring != NULL)
+    {
+        range_count = 1;
+    }
+    else if (cJSON_IsArray(range_json))
+    {
+        range_count = cJSON_GetArraySize(range_json);
+    }
+
+    if (range_count <= 0)
+    {
+        LOGF("JSON Error: PacketSender->settings->source-ip4-range (string or array field) : expected one or more IPv4 CIDR ranges");
+        return false;
+    }
+
+    state->source_ranges = memoryAllocateZero((size_t) range_count * sizeof(*(state->source_ranges)));
+    state->source_range_count = (uint32_t) range_count;
+
+    uint64_t total_source_count = 0;
+
+    for (int i = 0; i < range_count; ++i)
+    {
+        const cJSON *item = NULL;
+        char         json_path[128];
+        char        *cidr = NULL;
+
+        if (cJSON_IsArray(items))
+        {
+            item = cJSON_GetArrayItem(items, i);
+            stringNPrintf(json_path, sizeof(json_path), "PacketSender->settings->source-ip4-range[%d]", i);
+            if (! cJSON_IsString(item) || item->valuestring == NULL)
+            {
+                LOGF("JSON Error: %s (string field) : expected an IPv4 CIDR range", json_path);
+                return false;
+            }
+            cidr = item->valuestring;
+        }
+        else
+        {
+            item = items;
+            cidr = item->valuestring;
+            stringCopy(json_path, "PacketSender->settings->source-ip4-range");
+        }
+
+        if (! packetsenderParseSourceRange(&state->source_ranges[i], cidr, json_path))
+        {
+            return false;
+        }
+
+        if (state->source_ranges[i].count > (UINT64_MAX - total_source_count))
+        {
+            LOGF("PacketSender: total source range size overflow");
+            return false;
+        }
+
+        total_source_count += state->source_ranges[i].count;
+    }
+
+    state->source_count = total_source_count;
     return true;
 }
 
@@ -241,7 +316,7 @@ tunnel_t *packetsenderTunnelCreate(node_t *node)
         return NULL;
     }
 
-    if (! packetsenderLoadSourceRange(state, settings) || ! packetsenderLoadDestIpv4(state, settings) ||
+    if (! packetsenderLoadSourceRanges(state, settings) || ! packetsenderLoadDestIpv4(state, settings) ||
         ! packetsenderLoadProtocolMode(state, settings) || ! packetsenderLoadDuration(state, settings) ||
         ! packetsenderLoadDestPort(state, settings) || ! packetsenderLoadSrcPort(state, settings))
     {

--- a/tunnels/PacketSender/instance/destroy.c
+++ b/tunnels/PacketSender/instance/destroy.c
@@ -6,6 +6,12 @@ void packetsenderTunnelDestroy(tunnel_t *t)
 {
     packetsender_tstate_t *state = tunnelGetState(t);
 
+    if (state->source_ranges != NULL)
+    {
+        memoryFree(state->source_ranges);
+        state->source_ranges = NULL;
+    }
+
     if (state->workers != NULL)
     {
         for (wid_t wi = 0; wi < state->workers_count; ++wi)
@@ -30,4 +36,3 @@ void packetsenderTunnelDestroy(tunnel_t *t)
 
     tunnelDestroy(t);
 }
-


### PR DESCRIPTION
This PR extends PacketSender so "source-ip4-range" can accept either a single CIDR string or an ordered array of CIDR strings.\n\nBehavior:\n- preserves backward compatibility for the existing single-string form\n- consumes ranges sequentially in the provided order\n- updates docs and cleanup logic accordingly\n\nCherry-picked commit: c75f5f3b (original feature commit: c7b01d8f)